### PR TITLE
CI: Run on PRs and once a week

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,10 @@ name: build-and-test
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 env:
   LIBERICA_URL: https://download.bell-sw.com/java/17.0.3+7/bellsoft-jdk17.0.3+7-linux-amd64-full.tar.gz


### PR DESCRIPTION
Run the CI when a new PR opens, and once a week to check everything keeps working as environments get updated, new Python version and packages get released, etc.

Once a build fails, we only have to check what changed in the past week instead of the past 6+ months.